### PR TITLE
Fix URL to JS file

### DIFF
--- a/dist/theme/GerritSiteFooter.html
+++ b/dist/theme/GerritSiteFooter.html
@@ -1,1 +1,1 @@
-<script src="//https://cdn.rawgit.com/shellscape/OctoGerrit/v1.0.2/dist/octogerrit.js"></script>
+<script src="//cdn.rawgit.com/shellscape/OctoGerrit/v1.0.2/dist/octogerrit.js"></script>


### PR DESCRIPTION
The `GerritSiteFooter.html` file currently refers to the JS file in the following way:

```
 <script src="//https://cdn.rawgit.com/
```

Fix the protocol declaration.
